### PR TITLE
moved renderer to root of plugin

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -161,6 +161,6 @@ function mod_sectioncomplete_cm_info_view(cm_info $cm) {
     if (!$cm->uservisible) {
         return;
     }
-    $renderer = $PAGE->get_renderer('mod_sectioncomplete');
+    $renderer = $PAGE->get_renderer('sectioncomplete');
     $cm->set_content($renderer->display_content($cm), true);
 }

--- a/renderer.php
+++ b/renderer.php
@@ -25,13 +25,15 @@ require_once($CFG->dirroot . '/mod/sectioncomplete/lib.php');
 
 defined('MOODLE_INTERNAL') || die();
 
-class renderer extends \plugin_renderer_base {
+class mod_sectioncomplete_renderer extends \plugin_renderer_base {
 
     public function display_content(\cm_info $cm) {
-        global $CFG, $DB;
+        global $CFG, $DB, $USER;
 
         $title = $cm->name;
-        if(sectioncomplete_get_completion_state($cm, $USER->id)) {
+
+        //TODO Kieran, need to actually get the course, probably from $cm
+        if(sectioncomplete_get_completion_state(2,$cm, $USER->id)) {
             $button = $CFG->wwwroot ."/mod/sectioncomplete/pix/tocomplete.svg";
         } else {
             $button = $CFG->wwwroot ."/mod/sectioncomplete/pix/completed.svg";


### PR DESCRIPTION
Also added in global $USER and did a temp hard coded course id. It would seem more elegant if the renderer was not int he root of the project, but this is the same as various other plugins so perhaps it will do. 